### PR TITLE
PlaylistResource

### DIFF
--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\PlaylistResource\Pages;
+use App\Filament\Resources\PlaylistResource\RelationManagers\MusicRelationManager;
 use App\Models\Playlist;
 use App\Models\User;
 use Filament\Forms\Components\Select;
@@ -68,7 +69,7 @@ class PlaylistResource extends Resource
     public static function getRelations(): array
     {
         return [
-            //
+            MusicRelationManager::class,
         ];
     }
 

--- a/app/Filament/Resources/PlaylistResource.php
+++ b/app/Filament/Resources/PlaylistResource.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\PlaylistResource\Pages;
+use App\Models\Playlist;
+use App\Models\User;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class PlaylistResource extends Resource
+{
+    protected static ?string $model = Playlist::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $navigationLabel = 'Playlists';
+
+    protected static ?string $pluralModelLabel = 'Playlists';
+
+    protected static ?string $modelLabel = 'Playlist';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('title')
+                    ->label('Nom')
+                    ->required(),
+                Select::make('user_id')
+                    ->label('Utilisateur')
+                    ->searchable()
+                    ->options(
+                        User::all()->pluck('name', 'id')
+                    ),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('title')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('user.name')
+                    ->label('Utilisateur')
+                    ->searchable(),
+                Tables\Columns\TextColumn::make('music_count')->counts('music')
+                    ->label('Nombre de morceaux'),
+            ])
+            ->filters([
+                //
+            ])
+            ->actions([
+                //
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPlaylists::route('/'),
+            'create' => Pages\CreatePlaylist::route('/create'),
+            'edit' => Pages\EditPlaylist::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/PlaylistResource/Pages/CreatePlaylist.php
+++ b/app/Filament/Resources/PlaylistResource/Pages/CreatePlaylist.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Filament\Resources\PlaylistResource\Pages;
+
+use App\Filament\Resources\PlaylistResource;
+use Filament\Actions;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreatePlaylist extends CreateRecord
+{
+    protected static string $resource = PlaylistResource::class;
+}

--- a/app/Filament/Resources/PlaylistResource/Pages/EditPlaylist.php
+++ b/app/Filament/Resources/PlaylistResource/Pages/EditPlaylist.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PlaylistResource\Pages;
+
+use App\Filament\Resources\PlaylistResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditPlaylist extends EditRecord
+{
+    protected static string $resource = PlaylistResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PlaylistResource/Pages/ListPlaylists.php
+++ b/app/Filament/Resources/PlaylistResource/Pages/ListPlaylists.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Resources\PlaylistResource\Pages;
+
+use App\Filament\Resources\PlaylistResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListPlaylists extends ListRecords
+{
+    protected static string $resource = PlaylistResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Resources/PlaylistResource/RelationManagers/MusicRelationManager.php
+++ b/app/Filament/Resources/PlaylistResource/RelationManagers/MusicRelationManager.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Filament\Resources\PlaylistResource\RelationManagers;
+
+use App\Filament\Resources\MusicResource;
+use App\Models\Music;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Forms\Components\TextInput;
+
+class MusicRelationManager extends RelationManager
+{
+    protected static string $relationship = 'music';
+
+    protected static ?string $title = 'Musiques';
+
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                TextInput::make('title')
+                    ->required()
+                    ->maxLength(255),
+            ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table
+            ->recordTitleAttribute('title')
+            ->columns([
+                TextColumn::make('title'),
+            ])
+            ->filters([
+                //
+            ])
+            ->headerActions([
+                Action::make('add')
+                    ->label('Ajouter une musique')
+                    ->form([
+                        Select::make('music_id')
+                            ->label('Musique')
+                            ->searchable()
+                            ->options(
+                                Music::all()->pluck('title', 'id')
+                            )
+                            ->required(),
+                    ])
+                    ->action(fn (array $data) => $this->getOwnerRecord()->music()->attach($data['music_id'])),
+            ])
+            ->actions([
+                Tables\Actions\EditAction::make()
+                    ->label('')
+                    ->url(fn ($record) => MusicResource::getUrl('edit', ['record' => $record])),
+                Tables\Actions\DeleteAction::make()
+                    ->requiresConfirmation()
+                    ->label(''),
+            ])
+            ->bulkActions([
+                Tables\Actions\BulkActionGroup::make([
+                    Tables\Actions\DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Resources/UserResource/RelationManagers/PlaylistsRelationManager.php
+++ b/app/Filament/Resources/UserResource/RelationManagers/PlaylistsRelationManager.php
@@ -2,11 +2,11 @@
 
 namespace App\Filament\Resources\UserResource\RelationManagers;
 
+use App\Filament\Resources\PlaylistResource;
 use Filament\Forms\Components\TextInput;
 use Filament\Forms\Form;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Tables;
-use Filament\Tables\Actions\Action;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
 
@@ -45,10 +45,11 @@ class PlaylistsRelationManager extends RelationManager
             ])
             ->actions([
                 Tables\Actions\DeleteAction::make()
+                    ->requiresConfirmation()
                     ->label(''),
-                Action::make('list')
+                Tables\Actions\EditAction::make()
                     ->label('')
-                    ->icon('heroicon-o-musical-note'),
+                    ->url(fn ($record) => PlaylistResource::getUrl('edit', ['record' => $record])),
             ])
             ->bulkActions([
                 //


### PR DESCRIPTION
This commit adds the 'requiresConfirmation' option to the DeleteAction in the PlaylistsRelationManager class of the Filament admin panel. This enhancement ensures that a confirmation prompt is displayed before deleting a playlist, providing a better user experience and preventing accidental deletions.